### PR TITLE
Update librealsense build on cross compile

### DIFF
--- a/.github/workflows/packaging/install_dependencies.sh
+++ b/.github/workflows/packaging/install_dependencies.sh
@@ -17,7 +17,7 @@ git clone https://github.com/IntelRealSense/librealsense.git -b v2.45.0
 PWD=$(pwd)
 
 cd librealsense
-cmake -Bbuild -H.
+cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=false -H.
 cmake --build build --target install -j`nproc --all`
 ldconfig
 

--- a/.github/workflows/packaging/install_dependencies.sh
+++ b/.github/workflows/packaging/install_dependencies.sh
@@ -11,8 +11,8 @@ apt update \
     libgl1-mesa-dev \
     libglu1-mesa-dev
 
-## Build and install librealsense2 ##
-git clone https://github.com/IntelRealSense/librealsense.git
+## Build and install Intel RealSense SDK 2.0 v2.45.0 ##
+git clone https://github.com/IntelRealSense/librealsense.git -b v2.45.0
 
 PWD=$(pwd)
 


### PR DESCRIPTION
We we not specifying the version of librealsense we needed (which for 3.2.1, is 2.48). Also makes sense that we build against an optimized librealsense. The examples are not needed to be built (and they take a long time to build on the cross-compile while they are not actually required).