### PR TITLE
packaging: update colcon defaults

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -58,7 +58,8 @@ jobs:
             --arch ${{ matrix.arch }} \
             --os ubuntu \
             --rosdistro ${{ matrix.ros2_distro }} \
-            --custom-setup-script .github/workflows/packaging/install_dependencies.sh
+            --custom-setup-script .github/workflows/packaging/install_dependencies.sh \
+            --colcon-defaults /ros_ws/src/realsense-ros/.github/workflows/packaging/defaults.yaml
       - name: Create zip
         run: |
           cd /tmp/colcon_ws/install_${{ matrix.arch }}

--- a/.github/workflows/packaging/defaults.yaml
+++ b/.github/workflows/packaging/defaults.yaml
@@ -1,0 +1,3 @@
+build:
+  event-handlers: ["console_direct+"]
+  cmake-args: ["-DCMAKE_BUILD_TYPE=Release"]


### PR DESCRIPTION
Adds `defaults.yaml` file to configure colcon CLI entries, adding the build type and the events handler.