### PR TITLE
d455: enable RGB camera by default

### DIFF
--- a/realsense2_camera/config/d455_skynode.yaml
+++ b/realsense2_camera/config/d455_skynode.yaml
@@ -18,7 +18,7 @@ camera:
         infra_qos: "SENSOR_DATA"
 
         enable_accel: false
-        enable_color: false
+        enable_color: true
         enable_depth: true
         enable_gyro: false
         enable_infra1: true


### PR DESCRIPTION
@bastianhjaeger is there any reason against enabling the RGB camera on the d455 by default?